### PR TITLE
Enabled simultaneous use of repetition codes

### DIFF
--- a/releasenotes/notes/id-for-repetitioncode-3843125f90d9ebd8.yaml
+++ b/releasenotes/notes/id-for-repetitioncode-3843125f90d9ebd8.yaml
@@ -1,0 +1,10 @@
+---
+prelude: >
+    This release adds an optional argument to RepetitionCode, enabling to use
+    several repetition codes in the same circuit.
+features:
+  - |
+    When calling RepetitionCode, you can add an optional id argument, which
+    will be added to register names. This enables you to add several
+    repetition codes to the same circuit without getting register name
+    conflicts.

--- a/test/topological_codes/test_codes.py
+++ b/test/topological_codes/test_codes.py
@@ -314,6 +314,43 @@ class TestCodes(unittest.TestCase):
             self.assertTrue(test_passed, error)
         print('test_graph: ok')
 
+    def test_names(self):
+        """Test if register names are correctly altered when adding an id"""
+        test_passed = True
+
+        # Test when id is not specified
+        code = RepetitionCode(3,0)
+        code.syndrome_measurement()
+        for circ in code.get_circuit_list():
+            # Test link qubits
+            test_passed &= (circ.qregs[0]._name == "link_qubit_0")
+            error = ("Name of link qubit register should be link_qubit_0 but is " + circ.qregs[0]._name)
+            self.assertTrue(test_passed, error)
+            # Test code qubits
+            test_passed &= (circ.qregs[1]._name == "code_qubit_0")
+            error = ("Name of code qubit register should be code_qubit_0 but is " + circ.qregs[1]._name)
+            self.assertTrue(test_passed, error)
+            # Test link bits
+            test_passed &= (circ.cregs[0]._name == "round_0_link_bit_0")
+            error = ("Name of link bit register should be round_0_link_bit_0 but is " + circ.qregs[0]._name)
+            self.assertTrue(test_passed, error)
+
+        # Test when id is specified
+        code = RepetitionCode(3,0,id=1)
+        code.syndrome_measurement()
+        for circ in code.get_circuit_list():
+            # Test link qubits
+            test_passed &= (circ.qregs[0]._name == "link_qubit_1")
+            error = ("Name of link qubit register should be link_qubit_1 but is " + circ.qregs[0]._name)
+            self.assertTrue(test_passed, error)
+            # Test code qubits
+            test_passed &= (circ.qregs[1]._name == "code_qubit_1")
+            error = ("Name of code qubit register should be code_qubit_1 but is " + circ.qregs[1]._name)
+            self.assertTrue(test_passed, error)
+            # Test link bits
+            test_passed &= (circ.cregs[0]._name == "round_0_link_bit_1")
+            error = ("Name of link bit register should be round_0_link_bit_1 but is " + circ.qregs[0]._name)
+            self.assertTrue(test_passed, error)
 
 if __name__ == "__main__":
     unittest.main()

--- a/topological_codes/circuits.py
+++ b/topological_codes/circuits.py
@@ -26,7 +26,7 @@ class RepetitionCode:
     T syndrome measurement rounds.
     """
 
-    def __init__(self, d, T=0, xbasis=False, resets=False, delay=0, barriers=False):
+    def __init__(self, d, T=0, xbasis=False, resets=False, delay=0, barriers=False, id=0):
         """
         Creates the circuits corresponding to a logical 0 and 1 encoded
         using a repetition code.
@@ -49,13 +49,14 @@ class RepetitionCode:
 
         self.d = d
         self.T = 0
+        self.id = id
 
-        self.code_qubit = QuantumRegister(d, "code_qubit")
-        self.link_qubit = QuantumRegister((d - 1), "link_qubit")
+        self.code_qubit = QuantumRegister(d, "code_qubit_" + str(id))
+        self.link_qubit = QuantumRegister((d - 1), "link_qubit_" + str(id))
         self.qubit_registers = {"code_qubit", "link_qubit"}
 
         self.link_bits = []
-        self.code_bit = ClassicalRegister(d, "code_bit")
+        self.code_bit = ClassicalRegister(d, "code_bit_" + str(id))
 
         self.circuit = {}
         for log in ["0", "1"]:
@@ -135,7 +136,7 @@ class RepetitionCode:
         barrier = barrier or self._barriers
         
         self.link_bits.append(
-            ClassicalRegister((self.d - 1), "round_" + str(self.T) + "_link_bit")
+            ClassicalRegister((self.d - 1), "round_" + str(self.T) + "_link_bit_" + str(self.id))
         )
         
         for log in ["0", "1"]:

--- a/topological_codes/circuits.py
+++ b/topological_codes/circuits.py
@@ -38,6 +38,7 @@ class RepetitionCode:
             resets (bool): Whether to include a reset gate after mid-circuit measurements.
             delay (float): Time (in dt) to delay after mid-circuit measurements (and delay).
             barrier (bool): Boolean denoting whether to include a barrier at the end.
+            id (int): Repetition code id, in case you use several repetition codes in the same circuit
 
 
         Additional information:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
It was not possible to use several repetition codes inside the same circuit, because all codes had the same register names. I fixed this issue by adding an optional id parameter to RepetitionCode, enabling you to create unique register names.


### Details and comments
This is my first PR on this project, I tried to follow all the guidelines but am happy to correct any mistake or omission.